### PR TITLE
Errors not loaded if run does not throw exception

### DIFF
--- a/lib/smsc.rb
+++ b/lib/smsc.rb
@@ -115,6 +115,9 @@ class Smsc
   def send(num, msj, time=nil)
     begin
       response = run('enviar', nil, num, msj, time)
+      if response["code"] != 200
+        error(respone["code"])
+      end
       response["code"] == 200
     rescue => e
       error(response["code"])


### PR DESCRIPTION
I had an issue today where send was returning false but the errors array was empty, it seems that when your account reaches zero messages an exception isn't thrown in the run method so the response isn't 200 but the error is not loaded. 

Here's my solution, I think it's far from ideal so it would be great if you could improve it